### PR TITLE
Add assembly definitions for core modules

### DIFF
--- a/Assets/Scripts/Core/Core.asmdef
+++ b/Assets/Scripts/Core/Core.asmdef
@@ -1,0 +1,16 @@
+{
+    "name": "DungeonMaster.Core",
+    "rootNamespace": "DungeonMaster.Core",
+    "references": [
+        "GUID:27d509ea90a5443ea21efe3de268a1fd"
+    ],
+    "includePlatforms": [],
+    "excludePlatforms": [],
+    "allowUnsafeCode": false,
+    "overrideReferences": false,
+    "precompiledReferences": [],
+    "autoReferenced": true,
+    "defineConstraints": [],
+    "versionDefines": [],
+    "noEngineReferences": false
+}

--- a/Assets/Scripts/Core/Core.asmdef.meta
+++ b/Assets/Scripts/Core/Core.asmdef.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 89c4d957572047cca22ead59e5b9b7c9
+AssemblyDefinitionImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Data/Data.asmdef
+++ b/Assets/Scripts/Data/Data.asmdef
@@ -1,0 +1,14 @@
+{
+    "name": "DungeonMaster.Data",
+    "rootNamespace": "DungeonMaster.Data",
+    "references": [],
+    "includePlatforms": [],
+    "excludePlatforms": [],
+    "allowUnsafeCode": false,
+    "overrideReferences": false,
+    "precompiledReferences": [],
+    "autoReferenced": true,
+    "defineConstraints": [],
+    "versionDefines": [],
+    "noEngineReferences": false
+}

--- a/Assets/Scripts/Data/Data.asmdef.meta
+++ b/Assets/Scripts/Data/Data.asmdef.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 27d509ea90a5443ea21efe3de268a1fd
+AssemblyDefinitionImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Gameplay/Gameplay.asmdef
+++ b/Assets/Scripts/Gameplay/Gameplay.asmdef
@@ -1,0 +1,18 @@
+{
+    "name": "DungeonMaster.Gameplay",
+    "rootNamespace": "DungeonMaster.Gameplay",
+    "references": [
+        "GUID:8bad97eac4b94b89ae1c905ea1fc71c6",
+        "GUID:89c4d957572047cca22ead59e5b9b7c9",
+        "GUID:27d509ea90a5443ea21efe3de268a1fd"
+    ],
+    "includePlatforms": [],
+    "excludePlatforms": [],
+    "allowUnsafeCode": false,
+    "overrideReferences": false,
+    "precompiledReferences": [],
+    "autoReferenced": true,
+    "defineConstraints": [],
+    "versionDefines": [],
+    "noEngineReferences": false
+}

--- a/Assets/Scripts/Gameplay/Gameplay.asmdef.meta
+++ b/Assets/Scripts/Gameplay/Gameplay.asmdef.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: a9cba654ebae4cb7ae008d2b1e2434ad
+AssemblyDefinitionImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Systems/Systems.asmdef
+++ b/Assets/Scripts/Systems/Systems.asmdef
@@ -1,0 +1,17 @@
+{
+    "name": "DungeonMaster.Systems",
+    "rootNamespace": "DungeonMaster.Systems",
+    "references": [
+        "GUID:89c4d957572047cca22ead59e5b9b7c9",
+        "GUID:27d509ea90a5443ea21efe3de268a1fd"
+    ],
+    "includePlatforms": [],
+    "excludePlatforms": [],
+    "allowUnsafeCode": false,
+    "overrideReferences": false,
+    "precompiledReferences": [],
+    "autoReferenced": true,
+    "defineConstraints": [],
+    "versionDefines": [],
+    "noEngineReferences": false
+}

--- a/Assets/Scripts/Systems/Systems.asmdef.meta
+++ b/Assets/Scripts/Systems/Systems.asmdef.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 8bad97eac4b94b89ae1c905ea1fc71c6
+AssemblyDefinitionImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
## Summary
- add assembly definitions for core, data, systems, and gameplay modules
- wire up assembly references to match namespace hierarchy

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688ee70987d483279e1101d52312b6cd