### PR TITLE
refactor: move settings to dedicated namespace

### DIFF
--- a/Assets/ScriptableObjects/ArmorSettings.cs
+++ b/Assets/ScriptableObjects/ArmorSettings.cs
@@ -1,7 +1,7 @@
 using DungeonMaster.Data.Enums;
 using UnityEngine;
 
-namespace Settings
+namespace DungeonMaster.Settings
 {
     /// <summary>
     /// 방어구 타입별 효과(보호율, 공격속도 변화 등)를 정의하는 ScriptableObject입니다.

--- a/Assets/ScriptableObjects/CardBalanceSettings.cs
+++ b/Assets/ScriptableObjects/CardBalanceSettings.cs
@@ -1,6 +1,6 @@
 using UnityEngine;
 
-namespace Settings
+namespace DungeonMaster.Settings
 {
     /// <summary>
     /// 게임의 모든 핵심 밸런스 설정 ScriptableObject들을 중앙에서 관리하고 참조하는 허브 역할을 합니다.

--- a/Assets/ScriptableObjects/CardGradeSettings.cs
+++ b/Assets/ScriptableObjects/CardGradeSettings.cs
@@ -1,7 +1,7 @@
 using DungeonMaster.Data.Enums;
 using UnityEngine;
 
-namespace Settings
+namespace DungeonMaster.Settings
 {
     /// <summary>
     /// 카드 등급(C~UR)별 기본 스탯을 정의하는 ScriptableObject입니다.

--- a/Assets/ScriptableObjects/CriticalSettings.cs
+++ b/Assets/ScriptableObjects/CriticalSettings.cs
@@ -1,7 +1,7 @@
 using DungeonMaster.Data.Enums;
 using UnityEngine;
 
-namespace Settings
+namespace DungeonMaster.Settings
 {
     /// <summary>
     /// 치명타 등급(F~S)별 실제 치명타 관련 수치 범위를 정의하는 ScriptableObject입니다.

--- a/Assets/ScriptableObjects/ElementalSettings.cs
+++ b/Assets/ScriptableObjects/ElementalSettings.cs
@@ -1,7 +1,7 @@
 using DungeonMaster.Data.Enums;
 using UnityEngine;
 
-namespace Settings
+namespace DungeonMaster.Settings
 {
     /// <summary>
     /// 속성 간의 상성 관계 및 효과를 정의하는 ScriptableObject입니다.

--- a/Assets/ScriptableObjects/GameSettings.cs
+++ b/Assets/ScriptableObjects/GameSettings.cs
@@ -1,8 +1,8 @@
 using System.Collections.Generic;
-using Character;
+using DungeonMaster.Data;
 using UnityEngine;
 
-namespace Settings
+namespace DungeonMaster.Settings
 {
     /// <summary>
     /// 게임의 핵심 설정을 관리하는 ScriptableObject입니다.

--- a/Assets/ScriptableObjects/GrowthRateSettings.cs
+++ b/Assets/ScriptableObjects/GrowthRateSettings.cs
@@ -1,7 +1,7 @@
 using DungeonMaster.Data.Enums;
 using UnityEngine;
 
-namespace Settings
+namespace DungeonMaster.Settings
 {
     /// <summary>
     /// 성장률 등급(F~S)별 실제 성장률 수치 범위를 정의하는 ScriptableObject입니다.

--- a/Assets/ScriptableObjects/Settings.asmdef
+++ b/Assets/ScriptableObjects/Settings.asmdef
@@ -1,11 +1,8 @@
 {
-    "name": "DungeonMaster.Gameplay",
-    "rootNamespace": "DungeonMaster.Gameplay",
+    "name": "DungeonMaster.Settings",
+    "rootNamespace": "DungeonMaster.Settings",
     "references": [
-        "GUID:8bad97eac4b94b89ae1c905ea1fc71c6",
-        "GUID:89c4d957572047cca22ead59e5b9b7c9",
-        "GUID:27d509ea90a5443ea21efe3de268a1fd",
-        "GUID:e852a141fce9445588cc00c4ddd7d5d9"
+        "GUID:27d509ea90a5443ea21efe3de268a1fd"
     ],
     "includePlatforms": [],
     "excludePlatforms": [],

--- a/Assets/ScriptableObjects/Settings.asmdef.meta
+++ b/Assets/ScriptableObjects/Settings.asmdef.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: e852a141fce9445588cc00c4ddd7d5d9
+AssemblyDefinitionImporter:
+  externalObjects: {}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/ScriptableObjects/SkillSettings.cs
+++ b/Assets/ScriptableObjects/SkillSettings.cs
@@ -1,6 +1,6 @@
 using UnityEngine;
 
-namespace Settings
+namespace DungeonMaster.Settings
 {
     /// <summary>
     /// 스킬의 레벨별 효과 및 데이터를 정의하는 ScriptableObject입니다.

--- a/Assets/Scripts/Gameplay/Combat/Calculators/ArmorCalculator.cs
+++ b/Assets/Scripts/Gameplay/Combat/Calculators/ArmorCalculator.cs
@@ -1,5 +1,5 @@
 using DungeonMaster.Data.Enums;
-using Settings;
+using DungeonMaster.Settings;
 using UnityEngine;
 
 namespace DungeonMaster.Gameplay.Combat.Calculators

--- a/Assets/Scripts/Gameplay/Combat/Calculators/CriticalCalculator.cs
+++ b/Assets/Scripts/Gameplay/Combat/Calculators/CriticalCalculator.cs
@@ -1,5 +1,5 @@
 using DungeonMaster.Data.Enums;
-using Settings;
+using DungeonMaster.Settings;
 using UnityEngine;
 
 namespace DungeonMaster.Gameplay.Combat.Calculators

--- a/Assets/Scripts/Gameplay/Combat/Calculators/ElementalCalculator.cs
+++ b/Assets/Scripts/Gameplay/Combat/Calculators/ElementalCalculator.cs
@@ -1,5 +1,5 @@
 using DungeonMaster.Data.Enums;
-using Settings;
+using DungeonMaster.Settings;
 using UnityEngine;
 
 namespace DungeonMaster.Gameplay.Combat.Calculators


### PR DESCRIPTION
## Summary
- scope all ScriptableObject settings under `DungeonMaster.Settings`
- update gameplay calculators to consume new namespace
- add `Settings.asmdef` and reference it from gameplay assembly

## Testing
- `dotnet test` *(fails: Specify a project or solution file)*

------
https://chatgpt.com/codex/tasks/task_e_688ef370e3588327a0c8456382587899