### PR TITLE
chore: remove unused Unity archive and metadata

### DIFF
--- a/Assets/Scripts.zip
+++ b/Assets/Scripts.zip
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:b291515512fa06a6d356fc9ca85dc6fe377f21b162a61a70bb5934b6fcbfc4cc
-size 65644

--- a/Assets/Settings.meta
+++ b/Assets/Settings.meta
@@ -1,8 +1,0 @@
-fileFormatVersion: 2
-guid: 0220aab0833d04faeb927d84ca6cc40c
-folderAsset: yes
-DefaultImporter:
-  externalObjects: {}
-  userData: 
-  assetBundleName: 
-  assetBundleVariant: 


### PR DESCRIPTION
## Summary
- remove unused `Scripts.zip` file
- delete orphaned `Settings.meta`

## Testing
- `Unity -batchmode -quit -projectPath $(pwd)` *(fails: command not found)*
- `apt-get install -y unity-editor` *(fails: Unable to locate package)*

------
https://chatgpt.com/codex/tasks/task_e_688ef6c75c3c83278c65fa2914e6e027