### PR TITLE
refactor: decouple score manager from gameplay data

### DIFF
--- a/Assets/Scripts/Core/Interfaces/IScoreManager.cs
+++ b/Assets/Scripts/Core/Interfaces/IScoreManager.cs
@@ -1,11 +1,11 @@
-using DungeonMaster.Data.Enums;
+using DungeonMaster.Data.Structs;
 
 namespace DungeonMaster.Core.Interfaces
 {
     public interface IScoreManager
     {
         int TotalScore { get; }
-        void AddScore(EnemyType enemyType);
+        void AddScore(EnemyScoreInfo enemyInfo);
         void ResetScore();
     }
 }

--- a/Assets/Scripts/Data/Structs/EnemyScoreInfo.cs
+++ b/Assets/Scripts/Data/Structs/EnemyScoreInfo.cs
@@ -1,0 +1,15 @@
+using DungeonMaster.Data.Enums;
+
+namespace DungeonMaster.Data.Structs
+{
+    /// <summary>
+    /// 점수 계산에 필요한 적의 정보를 담는 구조체입니다.
+    /// </summary>
+    public struct EnemyScoreInfo
+    {
+        public string Name;      // 적의 이름 (로그 용도)
+        public EnemyType EnemyType; // 적의 종류
+        public int BaseScore;    // 처치 시 기본 점수
+    }
+}
+

--- a/Assets/Scripts/Data/Structs/EnemyScoreInfo.cs.meta
+++ b/Assets/Scripts/Data/Structs/EnemyScoreInfo.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 47fdcd7001814d4899a3745c7e25288c
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Scripts/Systems/Rewards/ScoreManager.cs
+++ b/Assets/Scripts/Systems/Rewards/ScoreManager.cs
@@ -2,7 +2,7 @@ using DungeonMaster.Core.Interfaces;
 using DungeonMaster.Core.Logging;
 using DungeonMaster.Data;
 using DungeonMaster.Data.Enums;
-using DungeonMaster.Gameplay.Actors;
+using DungeonMaster.Data.Structs;
 
 namespace DungeonMaster.Systems.Rewards
 {
@@ -33,21 +33,13 @@ namespace DungeonMaster.Systems.Rewards
             }
         }
         
-        public void AddScore(EnemyType enemyType)
-        {
-             // 이 메서드는 외부(GameFlowManager)에서 EnemyInfo를 받아 처리하도록 변경될 것입니다.
-             // 현재는 인터페이스와의 호환성을 위해 시그니처만 유지합니다.
-            throw new System.NotImplementedException("AddScore(EnemyInfo)를 사용해주세요.");
-        }
-
-
         /// <summary>
         /// 처치한 적의 정보를 바탕으로 점수를 계산하고 총 점수에 더합니다.
         /// </summary>
-        /// <param name="enemyInfo">처치한 적의 EnemyInfo 컴포넌트</param>
-        public void AddScore(EnemyInfo enemyInfo)
+        /// <param name="enemyInfo">처치한 적의 점수 정보</param>
+        public void AddScore(EnemyScoreInfo enemyInfo)
         {
-            if (enemyInfo == null || _rewardTable == null) return;
+            if (_rewardTable == null) return;
 
             float score = enemyInfo.BaseScore;
 
@@ -72,8 +64,8 @@ namespace DungeonMaster.Systems.Rewards
             
             int finalScore = UnityEngine.Mathf.RoundToInt(score);
             TotalScore += finalScore;
-            
-            GameLogger.Log($"적 처치! {enemyInfo.name} ({enemyInfo.EnemyType}) | 획득 점수: {finalScore} | 총 점수: {TotalScore}");
+
+            GameLogger.Log($"적 처치! {enemyInfo.Name} ({enemyInfo.EnemyType}) | 획득 점수: {finalScore} | 총 점수: {TotalScore}");
         }
 
         /// <summary>


### PR DESCRIPTION
## Summary
- add `EnemyScoreInfo` DTO for scoring
- refactor `ScoreManager` and `IScoreManager` to use DTO instead of `EnemyInfo`
- ensure Systems assembly only references Core and Data

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688f276b27cc832787efe4700c035b08